### PR TITLE
Edit student images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.5",
         "react-dom": "^18.3.1",
+        "react-dropzone": "^14.3.5",
         "react-router-dom": "^6.28.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
@@ -5774,6 +5775,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -8759,6 +8768,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.0.tgz",
+      "integrity": "sha512-ZuXAqGePcSPz4JuerOY06Dzzq0hrmQ6VGoXVzGyFI1npeOfBgqGIKKpznfYWRkSLJlXutkqVC5WvGZtkFVhu9Q==",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/filelist": {
@@ -14243,6 +14263,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",
     "react-dom": "^18.3.1",
+    "react-dropzone": "^14.3.5",
     "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, SyntheticEvent, MouseEvent } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Box, Typography, IconButton, Grid, Card, CardMedia, CardContent, Snackbar, Alert, Tooltip } from '@mui/material';
+import { Box, Typography, IconButton, Grid, Card, CardMedia, Snackbar, Alert, Tooltip } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 
 interface UploadedFile {
@@ -10,9 +10,10 @@ interface UploadedFile {
 
 interface FileUploadProps {
   onFilesChange: (files: UploadedFile[]) => void;
+  resetDropzone: boolean; // New prop to reset the dropzone
 }
 
-function FileUpload({ onFilesChange }: FileUploadProps) {
+function FileUpload({ onFilesChange, resetDropzone }: FileUploadProps) {
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [duplicateFileError, setDuplicateFileError] = useState(false);
 
@@ -52,9 +53,12 @@ function FileUpload({ onFilesChange }: FileUploadProps) {
     if (reason === 'clickaway') {
       return;
     }
-    event.stopPropagation();
     setDuplicateFileError(false);
   };
+
+  useEffect(() => {
+    setUploadedFiles([]);
+  }, [resetDropzone]);
 
   useEffect(() => {
     return () => {
@@ -92,22 +96,20 @@ function FileUpload({ onFilesChange }: FileUploadProps) {
                   objectFit: 'contain',
                 }}
               />
-              <CardContent sx={{ paddingBottom: '8px' }}>
-                <Tooltip title={file.name} arrow>
-                  <Typography 
-                    variant="body2" 
-                    noWrap 
-                    sx={{
-                      textOverflow: 'ellipsis',
-                      overflow: 'hidden',
-                      whiteSpace: 'nowrap',
-                      maxWidth: '100%',
-                    }}
-                  >
-                    {file.name}
-                  </Typography>
-                </Tooltip>
-              </CardContent>
+              <Tooltip title={file.name} arrow>
+                <Typography 
+                  variant="body2" 
+                  noWrap 
+                  sx={{
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '100%',
+                  }}
+                >
+                  {file.name}
+                </Typography>
+              </Tooltip>
               <IconButton
                 onClick={(event) => handleDelete(file.name, event)}
                 sx={{

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState, SyntheticEvent, MouseEvent } from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Box, Typography, IconButton, Grid, Card, CardMedia, CardContent, Snackbar, Alert, Tooltip } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface UploadedFile {
+  file: File;
+  preview: string;
+}
+
+interface FileUploadProps {
+  onFilesChange: (files: UploadedFile[]) => void;
+}
+
+function FileUpload({ onFilesChange }: FileUploadProps) {
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+  const [duplicateFileError, setDuplicateFileError] = useState(false);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: (acceptedFiles: File[]) => {
+      const nonDuplicateFiles = acceptedFiles.filter((newFile) => {
+        const isDuplicate = uploadedFiles.some((existingFile) => existingFile.file.name === newFile.name);
+        if (isDuplicate) {
+          setDuplicateFileError(true);
+        }
+        return !isDuplicate;
+      });
+
+      const newFiles = nonDuplicateFiles.map((file) => ({
+        file,
+        preview: URL.createObjectURL(file),
+      }));
+
+      setUploadedFiles((prevFiles) => {
+        const updatedFiles = [...prevFiles, ...newFiles];
+        onFilesChange(updatedFiles);  // Notify parent of file changes
+        return updatedFiles;
+      });
+    },
+  });
+
+  const handleDelete = (fileName: string, event: MouseEvent) => {
+    event.stopPropagation();
+    setUploadedFiles((prevFiles) => {
+      const updatedFiles = prevFiles.filter((f) => f.file.name !== fileName);
+      onFilesChange(updatedFiles);
+      return updatedFiles;
+    });
+  };
+
+  const handleCloseSnackbar = (event: SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    event.stopPropagation();
+    setDuplicateFileError(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      uploadedFiles.forEach((file) => URL.revokeObjectURL(file.preview));
+    };
+  }, [uploadedFiles]);
+
+  return (
+    <Box
+      {...getRootProps()}
+      sx={{
+        border: '2px dashed #1976d2',
+        borderRadius: '8px',
+        padding: '16px',
+        textAlign: 'center',
+        cursor: 'pointer',
+        backgroundColor: isDragActive ? '#e3f2fd' : '#fafafa',
+        transition: 'background-color 0.3s ease',
+      }}
+    >
+      <input {...getInputProps()} />
+      <Typography variant="h6" color="textSecondary" fontSize={17} fontWeight={100} marginBottom={'1rem'}>
+        {isDragActive ? 'Drop the files here ...' : 'Drag and drop files here, or click to select files'}
+      </Typography>
+      <Grid container spacing={2} marginBottom={'0.25rem'}>
+        {uploadedFiles.map(({ file, preview }) => (
+          <Grid item xs={12} sm={6} md={4} key={file.name}>
+            <Card sx={{ position: 'relative', maxWidth: 200, textAlign: 'center' }}>
+              <CardMedia
+                component="img"
+                height="140"
+                image={preview}
+                alt={file.name}
+                sx={{
+                  objectFit: 'contain',
+                }}
+              />
+              <CardContent sx={{ paddingBottom: '8px' }}>
+                <Tooltip title={file.name} arrow>
+                  <Typography 
+                    variant="body2" 
+                    noWrap 
+                    sx={{
+                      textOverflow: 'ellipsis',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '100%',
+                    }}
+                  >
+                    {file.name}
+                  </Typography>
+                </Tooltip>
+              </CardContent>
+              <IconButton
+                onClick={(event) => handleDelete(file.name, event)}
+                sx={{
+                  position: 'absolute',
+                  top: 8,
+                  right: 8,
+                  backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                  color: 'red',
+                }}
+                aria-label="delete"
+              >
+                <DeleteIcon />
+              </IconButton>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+      <Snackbar
+        open={duplicateFileError}
+        autoHideDuration={3000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleCloseSnackbar} severity="error" sx={{ width: '100%' }}>
+          Duplicate files are not allowed.
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}
+
+export default FileUpload;

--- a/src/pages/functionality/students/Students.tsx
+++ b/src/pages/functionality/students/Students.tsx
@@ -4,6 +4,7 @@ import { students } from '../../../configurations/StudentsConfigs';
 import Divider from '@mui/material/Divider';
 import AddStudentPopup from './AddStudentPopup';
 import { useState } from 'react';
+import ViewImagesPopup from './ViewImagesPopup';
 
 const paginationModel = { page: 0, pageSize: 5 };
 
@@ -18,69 +19,75 @@ export interface Student {
 
 function Students() {
 
-    const [studentsConfigs, setStudentsConfigs] = useState(students);
+  const [studentsConfigs, setStudentsConfigs] = useState(students);
 
-    const columnMetadata: GridColDef[] = [
-        { field: 'course', headerName: 'Course Code', width: 130},
-        { field: 'id', headerName: 'Student ID', width: 130 },
-        { field: 'firstName', headerName: 'First name', width: 150 },
-        { field: 'lastName', headerName: 'Last name', width: 150 },
-        { field: 'email', headerName: 'Email', width: 300 },
-        { 
-          field: 'photos', 
-          headerName: 'Photos', 
-          width: 100, 
-          renderCell: () => (
-              <Button variant="outlined" fullWidth>VIEW</Button>
-          ),
-        },
-        { 
-          field: 'actions', 
-          headerName: 'Actions', 
-          width: 100, 
-          renderCell: (params: GridRenderCellParams) => (
-            <Button
-              variant="outlined"
-              color="error"
-              onClick={() => handleDelete(params.row.id)}
-            >
-              Delete
-            </Button>
-          ),
-        }
-    ];
-
-    const handleAddStudent = (newStudent: Student) => {
-        setStudentsConfigs((prevConfigs) => [...prevConfigs, newStudent]);
-    };
-    
-    const handleDelete = (id: string) => {
-        setStudentsConfigs((prevConfigs) =>
-          prevConfigs.filter((student) => student.id !== id)
-        );
-    };
-
-    return (
-        <Paper sx={{ p: 2, width: '100%' }}>
-            <Typography variant="h5" fontWeight={1000} gutterBottom>
-                Student Management 
-            </Typography>
-            <Typography variant="body1" mb={'1rem'} gutterBottom>
-                    Manage all your students and their information here 
-            </Typography>
-            <Divider />
-            <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' >
-                <AddStudentPopup onAddStudent={handleAddStudent}  /> 
-            </Box>
-            <DataGrid
-                rows={studentsConfigs}
-                columns={columnMetadata}
-                initialState={{ pagination: { paginationModel } }}
-                pageSizeOptions={[5, 10, 20, 50]}
-                sx={{ border: 0 }}
+  const columnMetadata: GridColDef[] = [
+      { field: 'course', headerName: 'Course Code', width: 130 },
+      { field: 'id', headerName: 'Student ID', width: 130 },
+      { field: 'firstName', headerName: 'First name', width: 150 },
+      { field: 'lastName', headerName: 'Last name', width: 150 },
+      { field: 'email', headerName: 'Email', width: 250 },
+      { 
+        field: 'photos', 
+        headerName: 'Photos', 
+        width: 90, 
+        renderCell: (params: GridRenderCellParams) => (
+            <ViewImagesPopup 
+              course={params.row.course}
+              fullName={`${params.row.firstName} ${params.row.lastName}`} 
+              studentID={params.row.id}
+              email={params.row.email}
             />
-        </Paper>
-    );
+        ),
+      },
+      { 
+        field: 'actions', 
+        headerName: 'Actions', 
+        width: 110, 
+        renderCell: (params: GridRenderCellParams) => (
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => handleDelete(params.row.id)}
+          >
+            Delete
+          </Button>
+        ),
+      }
+  ];
+
+  const handleAddStudent = (newStudent: Student) => {
+      setStudentsConfigs([...studentsConfigs, newStudent]);
+  };
+  
+  const handleDelete = (id: string) => {
+      setStudentsConfigs((prevConfigs) =>
+        prevConfigs.filter((student) => student.id !== id)
+      );
+  };
+
+  return (
+      <Paper sx={{ p: 2, width: '100%' }}>
+          <Typography variant="h5" fontWeight={1000} gutterBottom>
+              Student Management 
+          </Typography>
+          <Typography variant="body1" mb={'1rem'} gutterBottom>
+                  Manage all your students and their information here 
+          </Typography>
+          <Divider />
+          <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' >
+              <AddStudentPopup onAddStudent={handleAddStudent}  /> 
+          </Box>
+          <DataGrid
+              rows={studentsConfigs}
+              columns={columnMetadata}
+              initialState={{ pagination: { paginationModel } }}
+              pageSizeOptions={[5, 10, 20, 50]}
+              sx={{ border: 0 }}
+              hideFooterSelectedRowCount={true}
+          />
+      </Paper>
+  );
 }
 
 export default Students;

--- a/src/pages/functionality/students/ViewImagesPopup.tsx
+++ b/src/pages/functionality/students/ViewImagesPopup.tsx
@@ -1,7 +1,18 @@
 import Button from '@mui/material/Button';
-import { Box, Modal, Paper, TextField, Typography } from '@mui/material';
-import { useState } from 'react';
-import { } from './Students';
+import { Box, Divider, Modal, Paper, Stack, TextField, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import FileUpload from '../../../components/ImageUpload';
+import {
+  CloudUpload as CloudUploadIcon,
+  Cancel as CancelIcon,
+  CheckCircle as CheckCircleIcon
+} from '@mui/icons-material';
+
+// Define UploadedFile type to match the one used in ImageUpload.tsx
+interface UploadedFile {
+  file: File;
+  preview: string;
+}
 
 interface ViewImagesPopupProps {
   course: string;
@@ -11,68 +22,114 @@ interface ViewImagesPopupProps {
 }
 
 function ViewImagesPopup(props: ViewImagesPopupProps) {
-
   const [open, setOpen] = useState(false);
+  const [uploadPhotos, setUploadPhotos] = useState(false);
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
 
-  const handleClose = () => {
+  useEffect(() => {
+    if (!open) {
+      setUploadPhotos(false);
+      setUploadedFiles([]);
+    }
+  }, [open]);
+
+  const handleUpload = () => {
+    console.log("Uploading files...");
     setOpen(false);
-  };
-  const handleOpen = () => {
-    setOpen(true);
   };
 
   return (
     <div>
-      <Button variant='outlined' onClick={handleOpen}>VIEW</Button>
+      <Button variant='outlined' onClick={() => setOpen(true)}>VIEW</Button>
       <Modal
         open={open}
-        onClose={handleClose}
+        onClose={() => setOpen(false)}
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
         sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
       >
         <Paper sx={{ p: 2, width: '50%', maxWidth: '500px' }}>
-            <Typography variant="h5" fontWeight={1000} gutterBottom>
-                Student Image Management 
-            </Typography>
-            <Typography variant="body1" gutterBottom>
-                Use this page to add or remove images for {props.fullName} 
-            </Typography>
-            <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
-                <TextField
-                    disabled
-                    id="fullName"
-                    label="Full Name"
+          <Typography variant="h5" fontWeight={1000} gutterBottom>
+            Student Image Management 
+          </Typography>
+          <Typography variant="body1" gutterBottom>
+            Use this page to add or remove images for {props.fullName} 
+          </Typography>
+          <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
+            <TextField
+              disabled
+              id="fullName"
+              label="Full Name"
+              fullWidth
+              defaultValue={props.fullName}
+              sx={{
+                color: 'black'
+              }}
+            />
+            <TextField
+              disabled
+              id="studentID"
+              label="Student ID"
+              fullWidth
+              defaultValue={props.studentID}
+            />
+          </Box>
+          <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
+            <TextField
+              disabled
+              id="email"
+              label="Email"
+              defaultValue={props.email}
+              fullWidth
+            />
+            <TextField
+              disabled
+              id="course"
+              label="Course Code"
+              defaultValue={props.course}
+              fullWidth
+            />
+          </Box>
+          <Divider />
+          <Stack spacing={2}>
+            <Box display="flex" gap={2} mt={2} justifyContent="center">
+              {uploadPhotos ? (
+                <>
+                  <Button
+                    variant="contained"
+                    onClick={() => setUploadPhotos(false)}
+                    startIcon={<CancelIcon />}
+                    color="error"
                     fullWidth
-                    defaultValue={props.fullName}
-                    sx={{
-                      color: 'black'
-                    }}
-                />
-                <TextField
-                    disabled
-                    id="studentID"
-                    label="Student ID"
-                    fullWidth
-                    defaultValue={props.studentID}
-                />
-            </Box>
-            <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
-              <TextField
-                  disabled
-                  id="email"
-                  label="Email"
-                  defaultValue={props.email}
+                  >
+                    Cancel Upload
+                  </Button>
+                  {uploadedFiles.length > 0 && (
+                    <Button
+                      variant="contained"
+                      color="success"
+                      onClick={handleUpload}
+                      startIcon={<CheckCircleIcon />}
+                      fullWidth
+                    >
+                      Upload Images
+                    </Button>
+                  )}
+                </>
+              ) : (
+                <Button
+                  component="label"
+                  variant="contained"
+                  onClick={() => setUploadPhotos(true)}
+                  startIcon={<CloudUploadIcon />}
                   fullWidth
-              />
-              <TextField
-                  disabled
-                  id="course"
-                  label="Course Code"
-                  defaultValue={props.course}
-                  fullWidth
-              />
+                >
+                  Upload
+                </Button>
+              )}
             </Box>
+            {uploadPhotos && <FileUpload onFilesChange={setUploadedFiles} />}
+          </Stack>
         </Paper>
       </Modal>
     </div>

--- a/src/pages/functionality/students/ViewImagesPopup.tsx
+++ b/src/pages/functionality/students/ViewImagesPopup.tsx
@@ -1,16 +1,20 @@
 import Button from '@mui/material/Button';
-import { Box, Divider, Modal, Paper, Stack, TextField, Typography } from '@mui/material';
+import { Avatar, Box, Divider, Grid, Modal, Paper, Stack, Typography, Card, CardMedia, IconButton } from '@mui/material';
 import { useEffect, useState } from 'react';
 import FileUpload from '../../../components/ImageUpload';
 import {
   CloudUpload as CloudUploadIcon,
   Cancel as CancelIcon,
-  CheckCircle as CheckCircleIcon
+  CheckCircle as CheckCircleIcon,
+  School as SchoolIcon,
+  Class as ClassIcon,
+  Email as EmailIcon,
+  Person as PersonIcon,
+  Delete as DeleteIcon,
 } from '@mui/icons-material';
 
-// Define UploadedFile type to match the one used in ImageUpload.tsx
 interface UploadedFile {
-  file: File;
+  file: File | null;
   preview: string;
 }
 
@@ -25,6 +29,8 @@ function ViewImagesPopup(props: ViewImagesPopupProps) {
   const [open, setOpen] = useState(false);
   const [uploadPhotos, setUploadPhotos] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+  const [submittedFiles, setSubmittedFiles] = useState<UploadedFile[]>([]); 
+  const [resetDropzone, setResetDropzone] = useState(false);
 
   useEffect(() => {
     if (!open) {
@@ -34,8 +40,13 @@ function ViewImagesPopup(props: ViewImagesPopupProps) {
   }, [open]);
 
   const handleUpload = () => {
-    console.log("Uploading files...");
-    setOpen(false);
+    setSubmittedFiles((prev) => [...prev, ...uploadedFiles]);
+    setUploadedFiles([]);
+    setResetDropzone((prev) => !prev);
+  };
+
+  const handleDeleteImage = (preview: string) => {
+    setSubmittedFiles((prevFiles) => prevFiles.filter((file) => file.preview !== preview));
   };
 
   return (
@@ -55,49 +66,103 @@ function ViewImagesPopup(props: ViewImagesPopupProps) {
           <Typography variant="body1" gutterBottom>
             Use this page to add or remove images for {props.fullName} 
           </Typography>
-          <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
-            <TextField
-              disabled
-              id="fullName"
-              label="Full Name"
-              fullWidth
-              defaultValue={props.fullName}
-              sx={{
-                color: 'black'
-              }}
-            />
-            <TextField
-              disabled
-              id="studentID"
-              label="Student ID"
-              fullWidth
-              defaultValue={props.studentID}
-            />
-          </Box>
-          <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
-            <TextField
-              disabled
-              id="email"
-              label="Email"
-              defaultValue={props.email}
-              fullWidth
-            />
-            <TextField
-              disabled
-              id="course"
-              label="Course Code"
-              defaultValue={props.course}
-              fullWidth
-            />
-          </Box>
-          <Divider />
+          <Divider sx={{ my: 2 }} />
+          <Grid container spacing={2} alignItems="center" paddingX='1rem' marginBottom='0.5rem'>
+            <Grid item>
+              <Avatar>
+                <PersonIcon />
+              </Avatar>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="subtitle1" fontWeight="bold">
+                Full Name
+              </Typography>
+              <Typography variant="body2">{props.fullName}</Typography>
+            </Grid>
+            <Grid item>
+              <Avatar>
+                <SchoolIcon />
+              </Avatar>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="subtitle1" fontWeight="bold">
+                Student ID
+              </Typography>
+              <Typography variant="body2">{props.studentID}</Typography>
+            </Grid>
+          </Grid>
+          <Grid container spacing={2} alignItems="center" paddingX='1rem' marginTop='0.5rem'>
+            <Grid item>
+              <Avatar>
+                <EmailIcon />
+              </Avatar>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="subtitle1" fontWeight="bold">
+                Email
+              </Typography>
+              <Typography variant="body2">{props.email}</Typography>
+            </Grid>
+            <Grid item>
+              <Avatar>
+                <ClassIcon />
+              </Avatar>
+            </Grid>
+            <Grid item xs>
+              <Typography variant="subtitle1" fontWeight="bold">
+                Course Code
+              </Typography>
+              <Typography variant="body2">{props.course}</Typography>
+            </Grid>
+          </Grid>
+          <Divider sx={{ my: 2 }} />
+          {submittedFiles.length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="h6" fontWeight={500} gutterBottom>
+                Previously Uploaded Images
+              </Typography>
+              <Grid container spacing={2}>
+                {submittedFiles.map(({ preview }) => (
+                  <Grid item xs={6} sm={4} key={preview}>
+                    <Card sx={{ position: 'relative', maxWidth: 120, textAlign: 'center' }}>
+                      <CardMedia
+                        component="img"
+                        height="100"
+                        image={preview}
+                        alt="Previously uploaded image"
+                        sx={{
+                          objectFit: 'cover',
+                        }}
+                      />
+                      <IconButton
+                        onClick={() => handleDeleteImage(preview)}
+                        sx={{
+                          position: 'absolute',
+                          top: 8,
+                          right: 8,
+                          backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                          color: 'red',
+                        }}
+                        aria-label="delete"
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </Card>
+                  </Grid>
+                ))}
+              </Grid>
+            </Box>
+          )}
           <Stack spacing={2}>
             <Box display="flex" gap={2} mt={2} justifyContent="center">
               {uploadPhotos ? (
                 <>
                   <Button
                     variant="contained"
-                    onClick={() => setUploadPhotos(false)}
+                    onClick={() => {
+                      setUploadPhotos(false);
+                      setUploadedFiles([]);
+                    }}
                     startIcon={<CancelIcon />}
                     color="error"
                     fullWidth
@@ -128,7 +193,7 @@ function ViewImagesPopup(props: ViewImagesPopupProps) {
                 </Button>
               )}
             </Box>
-            {uploadPhotos && <FileUpload onFilesChange={setUploadedFiles} />}
+            {uploadPhotos && <FileUpload onFilesChange={setUploadedFiles} resetDropzone={resetDropzone} />}
           </Stack>
         </Paper>
       </Modal>

--- a/src/pages/functionality/students/ViewImagesPopup.tsx
+++ b/src/pages/functionality/students/ViewImagesPopup.tsx
@@ -1,0 +1,82 @@
+import Button from '@mui/material/Button';
+import { Box, Modal, Paper, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+import { } from './Students';
+
+interface ViewImagesPopupProps {
+  course: string;
+  fullName: string;
+  studentID: string;
+  email: string;
+}
+
+function ViewImagesPopup(props: ViewImagesPopupProps) {
+
+  const [open, setOpen] = useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  return (
+    <div>
+      <Button variant='outlined' onClick={handleOpen}>VIEW</Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <Paper sx={{ p: 2, width: '50%', maxWidth: '500px' }}>
+            <Typography variant="h5" fontWeight={1000} gutterBottom>
+                Student Image Management 
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+                Use this page to add or remove images for {props.fullName} 
+            </Typography>
+            <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
+                <TextField
+                    disabled
+                    id="fullName"
+                    label="Full Name"
+                    fullWidth
+                    defaultValue={props.fullName}
+                    sx={{
+                      color: 'black'
+                    }}
+                />
+                <TextField
+                    disabled
+                    id="studentID"
+                    label="Student ID"
+                    fullWidth
+                    defaultValue={props.studentID}
+                />
+            </Box>
+            <Box display="flex" justifyContent="flex-start" mt='1.3rem' mb='1rem' gap={1.75}>
+              <TextField
+                  disabled
+                  id="email"
+                  label="Email"
+                  defaultValue={props.email}
+                  fullWidth
+              />
+              <TextField
+                  disabled
+                  id="course"
+                  label="Course Code"
+                  defaultValue={props.course}
+                  fullWidth
+              />
+            </Box>
+        </Paper>
+      </Modal>
+    </div>
+  );
+}
+
+export default ViewImagesPopup;


### PR DESCRIPTION
![CleanShot 2024-11-15 at 00 24 18](https://github.com/user-attachments/assets/cd31f2db-3d73-4e0e-ade9-2f93fdc337e0)

- Finished base functionality of the Student management page
- NOTE: The edit images functionality does not account for images to be persistent. So, once the images are uploaded for a given student and you exit the popup, when you reopen it, you won't be able to see the preview like you used to. As of now, this is not an issue since this can be fixed by DB integration.